### PR TITLE
Added support for getting extras in patch file

### DIFF
--- a/src/main/java/com/zutubi/diff/PatchFile.java
+++ b/src/main/java/com/zutubi/diff/PatchFile.java
@@ -12,6 +12,7 @@ import java.util.List;
 public class PatchFile
 {
     private List<Patch> patches = new LinkedList<Patch>();
+    private List<String> extendedInfo;
 
     /**
      * Returns a list of patches, one for each changed file in this patch file.
@@ -24,6 +25,17 @@ public class PatchFile
     }
 
     /**
+     * Returns the extended header lines in this patch file that may contain
+     * a information such as commit message.
+     *
+     * @return the extended info lines in this patch file (unmodifiable)
+     */
+    public List<String> getExtendedInfo()
+    {
+        return Collections.unmodifiableList(extendedInfo);
+    }
+
+    /**
      * Adds the given patch to this file.
      *
      * @param patch the patch to add
@@ -31,6 +43,16 @@ public class PatchFile
     public void addPatch(Patch patch)
     {
         patches.add(patch);
+    }
+
+    /**
+     * Adds the given extended header lines to this file.
+     *
+     * @param extendedInfo the extended header lines to add
+     */
+    public void addExtendedInfo(List<String> extendedInfo)
+    {
+        this.extendedInfo = new LinkedList<String>(extendedInfo);
     }
 
     /**

--- a/src/main/java/com/zutubi/diff/PatchFileParser.java
+++ b/src/main/java/com/zutubi/diff/PatchFileParser.java
@@ -4,6 +4,8 @@ import com.zutubi.diff.util.IOUtils;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * A generic patch file parser that can be used to parse files which are a
@@ -59,10 +61,11 @@ public class PatchFileParser
     private PatchFile read(PeekReader reader, PatchParser parser) throws IOException, PatchParseException
     {
         PatchFile patchFile = new PatchFile();
+        List<String> extendedInfo = new LinkedList<String>();
         while (!reader.spent())
         {
-            // Look for the patch header, skipping anything extra that may
-            // be in the way.
+            // Look for the patch header, putting anything extra into
+            // extendedInfo that may have a useful information.
             String line = reader.peek();
             if (parser.isPatchHeader(line))
             {
@@ -70,9 +73,11 @@ public class PatchFileParser
             }
             else
             {
+                extendedInfo.add(line);
                 reader.next();
             }
         }
+        patchFile.addExtendedInfo(extendedInfo);
 
         return patchFile;
     }


### PR DESCRIPTION
This patch adds support for getting extras in patch file
that contain commit author, date and message if parsed
file is a git patch file.
