### PR TITLE
Accept hunks with an optional section heading

### DIFF
--- a/src/main/java/com/zutubi/diff/unified/UnifiedHunk.java
+++ b/src/main/java/com/zutubi/diff/unified/UnifiedHunk.java
@@ -16,25 +16,31 @@ public class UnifiedHunk
     private long oldLength;
     private long newOffset;
     private long newLength;
+    private String sectionHeading;
 
     private List<Line> lines = new LinkedList<Line>();
 
     /**
      * Create a new hunk with the given locations in the old and new files.
      *
-     * @param oldOffset one-based line offset of the first corresponding line
-     *                  in the old file
-     * @param oldLength number of lines in the hunk that appear in the old file
-     * @param newOffset one-based line offset of the first corresponding line
-     *                  in the new file
-     * @param newLength number of lines in the hunk that appear in the new file
+     * @param oldOffset      one-based line offset of the first corresponding
+     *                       line in the old file
+     * @param oldLength      number of lines in the hunk that appear in the
+     *                       old file
+     * @param newOffset      one-based line offset of the first corresponding
+     *                       line in the new file
+     * @param newLength      number of lines in the hunk that appear in the
+     *                       new file
+     * @param sectionHeading the optional section heading that may be included
+     *                       to make the patch easier to read
      */
-    public UnifiedHunk(long oldOffset, long oldLength, long newOffset, long newLength)
+    public UnifiedHunk(long oldOffset, long oldLength, long newOffset, long newLength, String sectionHeading)
     {
         this.oldOffset = oldOffset;
         this.oldLength = oldLength;
         this.newOffset = newOffset;
         this.newLength = newLength;
+        this.sectionHeading = sectionHeading;
     }
 
     /**
@@ -69,6 +75,16 @@ public class UnifiedHunk
     public long getNewLength()
     {
         return newLength;
+    }
+
+    /**
+     * @return the section heading that may be included to make the patch
+     *         easier to read or null if the hunk does not have a section
+     *         heading
+     */
+    public String getSectionHeading()
+    {
+        return sectionHeading;
     }
 
     /**

--- a/src/main/java/com/zutubi/diff/unified/UnifiedPatchParser.java
+++ b/src/main/java/com/zutubi/diff/unified/UnifiedPatchParser.java
@@ -81,7 +81,7 @@ import java.util.regex.Pattern;
 public class UnifiedPatchParser implements PatchParser
 {
     private static final Pattern RE_EPOCH = Pattern.compile(".*(1970-01-01|\\(revision 0\\)).*");
-    private static final Pattern RE_HUNK = Pattern.compile("\\s*@@\\s+-(\\d+)(?:,(\\d+))?\\s+\\+(\\d+)(?:,(\\d+))?\\s+@@\\s*(.*)?");
+    private static final Pattern RE_HUNK = Pattern.compile("\\s*@@\\s+-(\\d+)(?:,(\\d+))?\\s+\\+(\\d+)(?:,(\\d+))?\\s+@@\\s*(.+)?");
 
     private static final char[] QUOTE_CHARS = new char[] { '"', '\'' };
 
@@ -138,8 +138,9 @@ public class UnifiedPatchParser implements PatchParser
                     long oldLength = parseOptionalLong(matcher.group(2));
                     long newOffset = Long.parseLong(matcher.group(3));
                     long newLength = parseOptionalLong(matcher.group(4));
+                    String sectionHeading = matcher.group(5);
 
-                    UnifiedHunk hunk = new UnifiedHunk(oldOffset, oldLength, newOffset, newLength);
+                    UnifiedHunk hunk = new UnifiedHunk(oldOffset, oldLength, newOffset, newLength, sectionHeading);
                     if (readHunkLines(reader, hunk))
                     {
                         patch.setNewlineTerminated(false);

--- a/src/main/java/com/zutubi/diff/unified/UnifiedPatchParser.java
+++ b/src/main/java/com/zutubi/diff/unified/UnifiedPatchParser.java
@@ -81,7 +81,7 @@ import java.util.regex.Pattern;
 public class UnifiedPatchParser implements PatchParser
 {
     private static final Pattern RE_EPOCH = Pattern.compile(".*(1970-01-01|\\(revision 0\\)).*");
-    private static final Pattern RE_HUNK = Pattern.compile("\\s*@@\\s+-(\\d+)(?:,(\\d+))?\\s+\\+(\\d+)(?:,(\\d+))?\\s+@@\\s*");
+    private static final Pattern RE_HUNK = Pattern.compile("\\s*@@\\s+-(\\d+)(?:,(\\d+))?\\s+\\+(\\d+)(?:,(\\d+))?\\s+@@\\s*(.*)?");
 
     private static final char[] QUOTE_CHARS = new char[] { '"', '\'' };
 

--- a/src/test/java/com/zutubi/diff/git/GitPatchParserTest.java
+++ b/src/test/java/com/zutubi/diff/git/GitPatchParserTest.java
@@ -2,6 +2,8 @@ package com.zutubi.diff.git;
 
 import com.zutubi.diff.*;
 import com.zutubi.diff.unified.UnifiedHunk;
+import com.zutubi.diff.unified.UnifiedHunk.Line;
+
 import junit.framework.Assert;
 
 import java.io.IOException;
@@ -22,12 +24,32 @@ public class GitPatchParserTest extends DiffTestCase
         assertPatchDetails(patch, "README.txt", "README.txt", PatchType.EDIT);
 
         List<UnifiedHunk> hunks = ((GitUnifiedPatch) patch).getHunks();
+        assertSimpleEdit(hunks);
+
+        UnifiedHunk hunk = hunks.get(0);
+        Assert.assertNull(hunk.getSectionHeading());
+    }
+
+    public void testSimpleEditWithSectionHeading() throws IOException, PatchParseException
+    {
+        GitPatch patch = parseSinglePatch();
+        assertPatchDetails(patch, "README.txt", "README.txt", PatchType.EDIT);
+
+        List<UnifiedHunk> hunks = ((GitUnifiedPatch) patch).getHunks();
+        assertSimpleEdit(hunks);
+
+        UnifiedHunk hunk = hunks.get(0);
+        Assert.assertEquals("a section heading", hunk.getSectionHeading());
+    }
+
+    private void assertSimpleEdit(List<UnifiedHunk> hunks)
+    {
         Assert.assertEquals(1, hunks.size());
 
         UnifiedHunk hunk = hunks.get(0);
         Assert.assertEquals(1, hunk.getOldOffset());
         Assert.assertEquals(6, hunk.getOldLength());
-        
+
         List<UnifiedHunk.Line> lines = hunk.getLines();
         Assert.assertEquals(8, lines.size());
         UnifiedHunk.Line line = lines.get(3);

--- a/src/test/resources/com/zutubi/diff/git/GitPatchParserTest.testSimpleEditWithSectionHeading.txt
+++ b/src/test/resources/com/zutubi/diff/git/GitPatchParserTest.testSimpleEditWithSectionHeading.txt
@@ -1,0 +1,13 @@
+diff --git a/README.txt b/README.txt
+index 32c2660..24eb6aa 100644
+--- a/README.txt
++++ b/README.txt
+@@ -1,6 +1,8 @@ a section heading
+ This library, clojure-contrib, has a dependency on Clojure: the clojure-lang JAR file. This is needed to compile the Clojure classes.
+ Normally, it is specified using -Dclojure.jar=<path>.
+ 
++Here is an edit.
++
+ The nightly-build and stable-build targets are intended for use on the Tapestry360 continuous integration server
+ (http://tapestry.formos.com/bamboo). They require the presense of the Maven Ant Tasks in the Ant lib folder.
+ 


### PR DESCRIPTION
The Unified format allows an optional section heading after the
specification of the hunk position like this:

```
@@ -l,s +l,s @@ optional section heading
```

The Pattern for hunks did not have a part to account for this section
heading and would not parse hunks with heading (because
Matcher.matches() is used, not Matcher.find()).

The Pattern has been extended to match hunks with section heading
(although the actual value is not used afterwards)
