### PR TITLE
Fix handling of quoted filenames

### DIFF
--- a/src/main/java/com/zutubi/diff/PatchFile.java
+++ b/src/main/java/com/zutubi/diff/PatchFile.java
@@ -85,6 +85,7 @@ public class PatchFile
 
     private File resolveDestination(File baseDir, String newFile, int prefixStripCount)
     {
+        newFile = stripQuotes(newFile);
         newFile = newFile.replace('\\', '/');
         int offset = 0;
         int i = 0;
@@ -100,5 +101,19 @@ public class PatchFile
         }
 
         return new File(baseDir, newFile.substring(i));
+    }
+
+    private String stripQuotes(String filename)
+    {
+        int len = filename.length();
+        if (len < 2) {
+            return filename;
+        }
+        char first = filename.charAt(0);
+        char last = filename.charAt(len - 1);
+        if (first == last && first == '"') {
+            return filename.substring(1, len - 1);
+        }
+        return filename;
     }
 }

--- a/src/test/java/com/zutubi/diff/PatchFileParserTest.java
+++ b/src/test/java/com/zutubi/diff/PatchFileParserTest.java
@@ -302,6 +302,16 @@ public class PatchFileParserTest extends DiffTestCase
         }
     }
 
+    public void testPatchFileWithSpaceCharactersUnquoted() throws Exception
+    {
+        singleFilePatchHelper(1);
+    }
+
+    public void testPatchFileWithSpaceCharactersQuoted() throws Exception
+    {
+        singleFilePatchHelper(1);
+    }
+
     private void readApplyAndCheck() throws Exception
     {
         readApplyAndCheck(convertName());
@@ -322,10 +332,15 @@ public class PatchFileParserTest extends DiffTestCase
 
     private void singleFilePatchHelper() throws PatchParseException, PatchApplyException, IOException
     {
+        singleFilePatchHelper(0);
+    }
+
+    private void singleFilePatchHelper(int prefixStripCount) throws PatchParseException, PatchApplyException, IOException
+    {
         PatchFile pf = parseSinglePatch();
         assertEquals(1, pf.getPatches().size());
         String patchedFile = pf.getPatches().get(0).getNewFile();
-        applyAndCheck(pf, 0, patchedFile);
+        applyAndCheck(pf, prefixStripCount, patchedFile);
     }
 
     private PatchFile parseSinglePatch() throws PatchParseException

--- a/src/test/resources/com/zutubi/diff/PatchFileParserTest.testPatchFileWithSpaceCharactersQuoted.txt
+++ b/src/test/resources/com/zutubi/diff/PatchFileParserTest.testPatchFileWithSpaceCharactersQuoted.txt
@@ -1,0 +1,11 @@
+--- "old/file with space characters.txt"	2009-04-01 11:30:22.000000000 +0200
++++ "new/file with space characters.txt"	2009-04-01 11:51:52.000000000 +0200
+@@ -6,7 +6,7 @@
+ special cases in some
+ patch formats (like
+ git's)
+-
++edit the blank line for fun
+ Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+ sed do eiusmod tempor incididunt ut labore et dolore
+ magna aliqua. Ut enim ad minim veniam, quis nostrud

--- a/src/test/resources/com/zutubi/diff/PatchFileParserTest.testPatchFileWithSpaceCharactersUnquoted.txt
+++ b/src/test/resources/com/zutubi/diff/PatchFileParserTest.testPatchFileWithSpaceCharactersUnquoted.txt
@@ -1,0 +1,11 @@
+--- old/file with space characters.txt	2009-04-01 11:30:22.000000000 +0200
++++ new/file with space characters.txt	2009-04-01 11:51:52.000000000 +0200
+@@ -6,7 +6,7 @@
+ special cases in some
+ patch formats (like
+ git's)
+-
++edit the blank line for fun
+ Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+ sed do eiusmod tempor incididunt ut labore et dolore
+ magna aliqua. Ut enim ad minim veniam, quis nostrud


### PR DESCRIPTION
So I was about to write test cases for #7, however I realized that the existing tests would not run on my machine (a Linux box with diff 3.3 installed). Apparently your version of diff does not quote filenames with spaces in their names, but my version does. I added some code that handles these cases by stripping the quotes if they are there. Otherwise resolving the destination files while applying the patches fails due to dangling quote characters in the resolved filename.

I also added tests for this by adding two patch files, one for the case with quoted filenames and another one for the case without quotes.