### PR TITLE
Add test cases for quoted filenames

### DIFF
--- a/src/test/java/com/zutubi/diff/PatchFileParserTest.java
+++ b/src/test/java/com/zutubi/diff/PatchFileParserTest.java
@@ -302,6 +302,21 @@ public class PatchFileParserTest extends DiffTestCase
         }
     }
 
+    public void testPatchFileWithSpaceCharactersUnquoted() throws Exception
+    {
+        singleFilePatchHelper(1);
+    }
+
+    public void testPatchFileWithSpaceCharactersSingleQuoted() throws Exception
+    {
+        singleFilePatchHelper(1);
+    }
+
+    public void testPatchFileWithSpaceCharactersDoubleQuoted() throws Exception
+    {
+        singleFilePatchHelper(1);
+    }
+
     private void readApplyAndCheck() throws Exception
     {
         readApplyAndCheck(convertName());
@@ -322,10 +337,15 @@ public class PatchFileParserTest extends DiffTestCase
 
     private void singleFilePatchHelper() throws PatchParseException, PatchApplyException, IOException
     {
+        singleFilePatchHelper(0);
+    }
+
+    private void singleFilePatchHelper(int prefixStripCount) throws PatchParseException, PatchApplyException, IOException
+    {
         PatchFile pf = parseSinglePatch();
         assertEquals(1, pf.getPatches().size());
         String patchedFile = pf.getPatches().get(0).getNewFile();
-        applyAndCheck(pf, 0, patchedFile);
+        applyAndCheck(pf, prefixStripCount, patchedFile);
     }
 
     private PatchFile parseSinglePatch() throws PatchParseException

--- a/src/test/resources/com/zutubi/diff/PatchFileParserTest.testPatchFileWithSpaceCharactersDoubleQuoted.txt
+++ b/src/test/resources/com/zutubi/diff/PatchFileParserTest.testPatchFileWithSpaceCharactersDoubleQuoted.txt
@@ -1,0 +1,11 @@
+--- "old/file with space characters.txt"	2009-04-01 11:30:22.000000000 +0200
++++ "new/file with space characters.txt"	2009-04-01 11:51:52.000000000 +0200
+@@ -6,7 +6,7 @@
+ special cases in some
+ patch formats (like
+ git's)
+-
++edit the blank line for fun
+ Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+ sed do eiusmod tempor incididunt ut labore et dolore
+ magna aliqua. Ut enim ad minim veniam, quis nostrud

--- a/src/test/resources/com/zutubi/diff/PatchFileParserTest.testPatchFileWithSpaceCharactersSingleQuoted.txt
+++ b/src/test/resources/com/zutubi/diff/PatchFileParserTest.testPatchFileWithSpaceCharactersSingleQuoted.txt
@@ -1,0 +1,11 @@
+--- 'old/file with space characters.txt'	2009-04-01 11:30:22.000000000 +0200
++++ 'new/file with space characters.txt'	2009-04-01 11:51:52.000000000 +0200
+@@ -6,7 +6,7 @@
+ special cases in some
+ patch formats (like
+ git's)
+-
++edit the blank line for fun
+ Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+ sed do eiusmod tempor incididunt ut labore et dolore
+ magna aliqua. Ut enim ad minim veniam, quis nostrud

--- a/src/test/resources/com/zutubi/diff/PatchFileParserTest.testPatchFileWithSpaceCharactersUnquoted.txt
+++ b/src/test/resources/com/zutubi/diff/PatchFileParserTest.testPatchFileWithSpaceCharactersUnquoted.txt
@@ -1,0 +1,11 @@
+--- old/file with space characters.txt	2009-04-01 11:30:22.000000000 +0200
++++ new/file with space characters.txt	2009-04-01 11:51:52.000000000 +0200
+@@ -6,7 +6,7 @@
+ special cases in some
+ patch formats (like
+ git's)
+-
++edit the blank line for fun
+ Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+ sed do eiusmod tempor incididunt ut labore et dolore
+ magna aliqua. Ut enim ad minim veniam, quis nostrud


### PR DESCRIPTION
I included three patch files generated with and without quotes and added tests that run with these files as the other test cases do.

I also created an overloaded version of `singleFilePatchHelper` that accepts the `prefixStripCount` argument which gets passed on to `applyAndCheck`.